### PR TITLE
Ignore already processed comments and submissions

### DIFF
--- a/src/TextifyBot.py
+++ b/src/TextifyBot.py
@@ -1,7 +1,7 @@
 # TextifyBot.py - Team BDF - CS 298-01 S19 WCSU
 
-# This python script identified comments that should eventually be processed
-# by our bot within a specific set of subreddits
+# This python script transcribes text from images in comments and submissions
+# that have been requested by a Reddit comment
 
 import os
 import urllib.request
@@ -16,8 +16,9 @@ SUBREDDIT = 'BDFTest' # subreddit to search for comments in (multiple subreddits
                       # can be specified by placing a '+' between them)
 IMAGE_DIR = 'images/' # directory to temporarily download images to
 TESSERACT_PATH = 'C:\\Program Files\\Tesseract-OCR\\tesseract.exe'
-POST_LEDGER = 'processedPosts.txt' # file that contains a list of comments
-                                         # that have been processed (delim: \n)
+POST_LEDGER = 'processedPosts.txt' # file that contains a list of IDs of
+                                   # comments and submissions that have been
+                                   # processed (delim: \n)
 
 
 def findTextInSubreddit(connection, sub, keyword):

--- a/src/TextifyBot.py
+++ b/src/TextifyBot.py
@@ -36,7 +36,7 @@ def findTextInSubreddit(connection, sub, keyword):
                         print(urls)
                         print('Text transcribed:')
                         print(transcribeImages(urls))
-                        markCommentAsProcessed(comment.parent().id)
+                    markPostIDAsProcessed(comment.parent().id)
                 elif isinstance(comment.parent(), praw.models.Submission):
                     print('Submission to textify:')
                     print(comment.parent().url)


### PR DESCRIPTION
This PR makes it so the bot does not process posts (which includes comments and submissions) more than once. This is done by maintaining a "ledger" of post IDs that have already been processed by the bot.

In the future, a more efficient and reliable solution will be possible. See related discussion in issue #23.

Closes #23