### PR TITLE
Format fix to remove markdown syntax from post/reply

### DIFF
--- a/src/TextifyBot.py
+++ b/src/TextifyBot.py
@@ -36,16 +36,16 @@ def findTextInSubreddit(connection):
                     print('URL(s) found:')
                     print(urls)
                     print('Text transcribed:')
-                    print(transcribeImages(urls))
+                    print(arrayToString(transcribeImages(urls)))
                     if checker:
-                        mention.reply(str(transcribeImages(urls)))
+                        mention.reply(arrayToString(transcribeImages(urls)))
                         checker = False
                 markPostIDAsProcessed(mention.parent().id)
             elif isinstance(mention.parent(), praw.models.Submission):
                 print('Submission to textify:')
                 print(mention.parent().url)
                 if checker:
-                    mention.reply(str(transcribeImages(urls)))
+                    mention.reply(arrayToString(transcribeImages(urls)))
                     checker = False                
                 markPostIDAsProcessed(mention.parent().id)
 
@@ -111,6 +111,14 @@ def transcribeImages(imagesToDL): # download and transcribe a list of image URLs
                 print("WARNING: HTTPError when downloading " + imageURL + ":\n")
                 print(str(e) + '\n')
     return transcribedText
+
+#Extract characters from array into a string variable
+def arrayToString(textArray):
+    str = ""
+    for x in textArray:
+        str = str + x
+    return str
+
 
 
 # Main driver code

--- a/src/TextifyBot.py
+++ b/src/TextifyBot.py
@@ -114,12 +114,25 @@ def transcribeImages(imagesToDL): # download and transcribe a list of image URLs
 
 #Extract characters from array into a string variable
 def arrayToString(textArray):
-    str = ""
+    str1 = ""
     for x in textArray:
-        str = str + x
-    return str
+        str1 = str1 + x
+    return markdownSyntax(str1)
 
-
+def markdownSyntax(str1):
+    x = 0
+    while x < len(str1):
+        index1 = str1.find('\n', x)
+        index2 = str1.find('\n', index1 + 1)
+        if index1 == -1:
+            break
+        elif index1 - index2 == -1:
+            x = index1 + 2
+        else:
+            str2 = str1[:index1] + '\n' + str1[index1:]
+            str1 = str2
+            x = index1 + 2
+    return str1
 
 # Main driver code
 if __name__ == '__main__': # This if statement guards this code from being executed when this file is imported

--- a/src/TextifyBot.py
+++ b/src/TextifyBot.py
@@ -119,6 +119,7 @@ def arrayToString(textArray):
         str1 = str1 + x
     return markdownSyntax(str1)
 
+#Function to properly format new lines
 def markdownSyntax(str1):
     x = 0
     while x < len(str1):


### PR DESCRIPTION
The cause for the bot posting replies that still contained markdown syntax was that the bot was posting/replying with an array that stored the transcribed text. The quick fix for this was to create a function that creates an empty string variable then concatenates each element in order from the array to the string variable and then finally returns the string variable. The function was then implemented where ever the TranscribeImages() function was called.