### PR TITLE
Have bot run continuously

### DIFF
--- a/src/TextifyBot.py
+++ b/src/TextifyBot.py
@@ -9,6 +9,7 @@ import botSetup
 import praw
 import PIL
 import pytesseract
+import time
 
 # Note: both WHITELIST and BLACKLIST are case insensitive; WHITELIST overrides
 # BLACKLIST if a subreddit exists in both lists
@@ -105,4 +106,6 @@ def transcribeImages(imagesToDL): # download and transcribe a list of image URLs
 # Main driver code
 if __name__ == '__main__': # This if statement guards this code from being executed when this file is imported
     bot = botSetup.textify_login()
-    processUsernameMentions(bot)
+    while True:
+        processUsernameMentions(bot)
+        time.sleep(5)

--- a/src/TextifyBot.py
+++ b/src/TextifyBot.py
@@ -22,11 +22,18 @@ CHECKER = True # enables posting to Reddit
 
 
 def processUsernameMentions(connection):
-    for newMessage in connection.inbox.unread(limit=None):
-        if isinstance(newMessage, praw.models.Mention):
-            processMention(newMessage)
+    for newMsg in connection.inbox.unread():
+        if isinstance(newMsg, praw.models.Comment) and isMention(newMsg):
+            processMention(newMsg)
             if CHECKER:
-                newMessage.mark_read()
+                newMsg.mark_read()
+
+
+def isMention(message):
+    if isinstance(message, praw.models.Comment):
+        return message.subject == 'username mention'
+    else:
+        return False
 
 
 def processMention(mention):

--- a/src/TextifyBot.py
+++ b/src/TextifyBot.py
@@ -28,7 +28,8 @@ def processUsernameMentions(connection):
     for newMessage in connection.inbox.unread(limit=None):
         if isinstance(newMessage, praw.models.Mention):
             processMention(newMessage)
-            newMessage.mark_read()
+            if CHECKER:
+                newMessage.mark_read()
 
 
 def processMention(mention):


### PR DESCRIPTION
In this PR, the bot is modified so that it runs non-stop. Previously, when the bot processed all of the mentions received, it would stop execution until it was manually restarted. Now, it runs non-stop until it is manually stopped (for example, by `CTRL-C`). It will periodically check for new mentions (currently every 5 seconds).

This PR also performs some optimizations that makes the bot much more efficient. Instead of maintaining a ledger of processed posts, it instead uses the unread/read status of a Reddit message to know whether a comment was processed or not.

Closes #24 