### PR TITLE
Remove improveImage function

### DIFF
--- a/src/TextifyBot.py
+++ b/src/TextifyBot.py
@@ -84,20 +84,10 @@ def allowedToParse(postID):
 
 
 def tesseractTranscribe(imagePath):
-    image = PIL.Image.open(improveImage(imagePath))
+    image = PIL.Image.open(imagePath)
     pytesseract.pytesseract.tesseract_cmd = TESSERACT_PATH
 
     return pytesseract.image_to_string(image)
-
-
-# Makes the given image larger to improve success of transcription
-def improveImage(imagePath):
-    image = Image.open(imagePath)
-    width = image.width
-    height = image.height
-    image = image.resize((width*2, height*2))
-    image.save(imagePath)
-    return imagePath
 
 
 def transcribeImages(imagesToDL): # download and transcribe a list of image URLs


### PR DESCRIPTION
This PR removes the pre-processing implemented in Milestone 4. The pre-processing improved some transcription results but made other transcription results noticeably worse. We will revisit pre-processing at a later date. Closes #65 