### PR TITLE
Fix submission handling and optimize transcription

### DIFF
--- a/src/TextifyBot.py
+++ b/src/TextifyBot.py
@@ -55,12 +55,13 @@ def processMention(mention):
             print('URL(s) found:')
             print(urls)
             print('Text transcribed:')
-            print(transcribeImages(urls))
+            result = transcribeImages(urls)
+            print(result)
             if CHECKER:
-                if arrayToString(transcribeImages(urls)) == '' or arrayToString(transcribeImages(urls)) == ' ':
+                if arrayToString(result) == '' or arrayToString(result) == ' ':
                     mention.reply("Transcription was unable to identify any text within the image")
                 else:
-                    mention.reply(arrayToString(transcribeImages(urls)))
+                    mention.reply(arrayToString(result))
         else:
             if CHECKER:
                 mention.reply("No URL(s) found")

--- a/src/TextifyBot.py
+++ b/src/TextifyBot.py
@@ -66,10 +66,21 @@ def processMention(mention):
             if CHECKER:
                 mention.reply("No URL(s) found")
     elif isinstance(mention.parent(), praw.models.Submission):
-        print('Submission to textify:')
-        print(mention.parent().url)
-        if CHECKER:
-            mention.reply(arrayToString(transcribeImages(urls)))
+        urls = botSetup.extractURL(mention.parent().url)
+        if urls != None:
+            print('URL(s) found:')
+            print(urls)
+            print('Text transcribed:')
+            result = transcribeImages(urls)
+            print(result)
+            if CHECKER:
+                if arrayToString(result) == '' or arrayToString(result) == ' ':
+                    mention.reply("Transcription was unable to identify any text within the image")
+                else:
+                    mention.reply(arrayToString(result))
+        else:
+            if CHECKER:
+                mention.reply("No URL(s) found")
 # - Post's subreddit must not be in blacklist
 # - Post's subreddit must be in whitelist if whitelist is not disabled by '*'
 def allowedToParse(postID):


### PR DESCRIPTION
This PR addresses two distinct issues (sorry).

1. Submissions are now successfully processed. As noted in a commit description, code is now repeated across processing of comments and submissions. This will be dealt with at a later time (an issue should be opened)

2. Images are now only processed once during the transcription process. Previously, an images would go through Tesseract up to 4 times due to the result not being stored.

Closes #64, Closes #66 