### PR TITLE
Add sample use of computer vision API

### DIFF
--- a/src/TextifyVision.py
+++ b/src/TextifyVision.py
@@ -1,0 +1,33 @@
+# TextifyVision.py - Team BDF - CS 298-01 S19 WCSU
+
+# This python script provides functions for using Textiy's implementation of
+# Micrisoft Azure's Computer Vision API
+
+# The current implementation is based off of this quick-start guide:
+# https://docs.microsoft.com/en-us/azure/cognitive-services/Computer-vision/QuickStarts/python-analyze
+
+import requests
+import json
+import authentication
+
+ANALYZE_URL = authentication.cvBaseURL + "/vision/v2.0/analyze"
+
+# 0: a basketball about to enter a baskeball hoop
+# 1: a plate of pasta topped with cheese and basil with bread in the background
+urlsToAnalyze = ["https://i.imgur.com/045nXnj.jpg", "https://i.imgur.com/U598smz.jpg"]
+
+for imageURL in urlsToAnalyze:
+    callHeader = {"Ocp-Apim-Subscription-Key": authentication.cvKey1}
+    callParams = {'visualFeatures': "Categories,Description,Color"}
+    callData = {"url": imageURL}
+
+    response = requests.post(ANALYZE_URL, headers=callHeader, params=callParams, json=callData)
+    response.raise_for_status()
+
+    result = response.json()
+    #print(json.dumps(result))
+
+    imageCaption = result["description"]["captions"][0]["text"]
+    captionConfidence = result["description"]["captions"][0]["confidence"]
+    print("I am " + str(captionConfidence * 100) + "% sure that this is:")
+    print(imageCaption + "\n")

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -3,3 +3,4 @@ praw==6.1.1
 pytesseract==0.2.6
 Pillow==5.4.1
 pytest==4.4.0
+requests==2.21.0


### PR DESCRIPTION
This PR adds a demonstration of how the Azure computer vision API could be used. The implementation is based off of [this quick start guide](https://docs.microsoft.com/en-us/azure/cognitive-services/Computer-vision/QuickStarts/python-analyze), but instead of displaying the image, the most confident caption is printed out to the console along with the API's confidence.

The API currently calls [this](https://i.imgur.com/045nXnj.jpg) "a close up of a basketball game" with  82.15117779200362% confidence, and [this](https://i.imgur.com/U598smz.jpg) "a white plate topped with different types of food" with 99.1333057984532% confidence.

Getting to this point was much easier than I expected. From here, we just need to integrate this with the rest of the bot (detecting a keyword and calling the API in response). 

Currently, the new file (`TextifyVision.py`) is run independently of the other files in the project (apart from the newest `authentication.py`).