### PR TITLE
Add sample use of translator API

### DIFF
--- a/src/TextifyTranslate.py
+++ b/src/TextifyTranslate.py
@@ -1,0 +1,36 @@
+# TextifyTranslate.py - Team BDF - CS 298-01 S19 WCSU
+
+# Script for implementing Microsoft Azure's Translator API
+
+# The current implementation is based off of this quick-start guide:
+# https://docs.microsoft.com/en-us/azure/cognitive-services/translator/quickstart-python-translate
+
+import requests
+import uuid
+import json
+import authentication
+
+subscriptionKey = authentication.ttKey1
+textToTranslate = 'Hi, I am a computer science student at Western Connecticut State University!'
+desiredLanguage = 'pt'
+
+base_url = 'https://api.cognitive.microsofttranslator.com'
+path = '/translate?api-version=3.0'
+params = '&to=' + desiredLanguage
+constructed_url = base_url + path + params
+
+headers = {
+    'Ocp-Apim-Subscription-Key': subscriptionKey,
+    'Content-type': 'application/json',
+    'X-ClientTraceId': str(uuid.uuid4())
+}
+
+body = [{
+    'text' : textToTranslate
+}]
+
+request = requests.post(constructed_url, headers=headers, json=body)
+response = request.json()
+
+translatedText = response[0]['translations'][0]['text']
+print(translatedText)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,3 +4,4 @@ pytesseract==0.2.6
 Pillow==5.4.1
 pytest==4.4.0
 requests==2.21.0
+uuid==1.30

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,4 +4,3 @@ pytesseract==0.2.6
 Pillow==5.4.1
 pytest==4.4.0
 requests==2.21.0
-uuid==1.30


### PR DESCRIPTION
This PR adds an example use of Microsoft Azure's Translator API. This implementation is based off [this quick start guide](https://docs.microsoft.com/en-us/azure/cognitive-services/translator/quickstart-python-translate). The *TextifyTranslate.py* script was fairly easy to figure out and shouldn't be too difficult to integrate with the current bot. We just would basically just need to supply the desired language and the text to be translated. 