### PR TITLE
add parameterized extractUsername unit tests

### DIFF
--- a/src/TextifyBot.py
+++ b/src/TextifyBot.py
@@ -107,9 +107,6 @@ def processMention(mention):
                     mention.reply("Transcription was unable to identify any text within the image")
                 else:
                     makeReply(mention, result)
-        else:
-            if CHECKER:
-                mention.reply("No URL(s) found")
 
 # - Post's subreddit must not be in blacklist
 # - Post's subreddit must not be NSFW (+18)
@@ -140,7 +137,7 @@ def makeReply(mention, transcriptions):
         else:
             print("unable to find link")
             response = response + '\n\nUnable to find associated twitter link'
-                
+
     #check for translation flag
     if mention.body.find(TRANSLATE_FLAG) >=0:
         for langCode in TextifyTranslate.LANGUAGE_CODE:

--- a/tests/test_TextifyBot.py
+++ b/tests/test_TextifyBot.py
@@ -43,3 +43,20 @@ def test_arrayToString(inputList, expectedString):
     ])
 def test_escapeMarkdown(markdownInput, markdownExpected):
     assert TextifyBot.escapeMarkdown(markdownInput) == markdownExpected
+
+handle = []
+handle.append('Hello I am searching for usernames, could come at the end @username')
+handle.append('@bbacon and lets see it pick something from the beginning as well')
+handle.append('It should @handle @multiple @usernames')
+handle.append('What if there are no usernames?')
+handle.append('@username checking @split usernames')
+@pytest.mark.parametrize("extractUsernameInput,extractUsernameExpected",
+    [
+        (handle[0], ['@username']),
+        (handle[1], ['@bbacon']),
+        (handle[2], ['@handle', '@multiple', '@usernames']),
+        (handle[3], []),
+        (handle[4], ['@username', '@split'])
+    ])
+def test_extractUsername(extractUsernameInput, extractUsernameExpected):
+    assert TextifyBot.extractUsername(extractUsernameInput) == extractUsernameExpected


### PR DESCRIPTION
This PR adds unit tests for the `extractUsername` function. You will also code to remove an unnecessary else. This is being addressed in another PR but I needed it for the code to run on my local so feel free to disregard. Closes #88 